### PR TITLE
fix: shop grid

### DIFF
--- a/src/components/common/item/item-list.tsx
+++ b/src/components/common/item/item-list.tsx
@@ -66,7 +66,7 @@ export default function ItemList({ initialParams }: ItemListGridProps) {
             chunkList(items, params.frame === 'grid' ? 2 : 3).map((group, idx) => {
               const ItemPreview = params.frame === 'grid' ? ItemPreviewGrid : ItemPreviewMasonry;
 
-              const placeholders = Array(params.frame === 'grid' ? 2 : 3 - group.length).fill(null);
+              const placeholders = Array((params.frame === 'grid' ? 2 : 3) - group.length).fill(null);
 
               return (
                 <div key={`item-list-group-${params.frame}-${idx}`} className={`flex justify-between`}>


### PR DESCRIPTION
삼항 연산자와 마이너스 기호 사이의 우선순위 혼동